### PR TITLE
Fix mixed-up box drawing double-single corners

### DIFF
--- a/src/basefont/OldTimeyMono.sfd
+++ b/src/basefont/OldTimeyMono.sfd
@@ -4000,18 +4000,18 @@ VStem: 336 84<-336 486> 588 84<-336 486>
 LayerCount: 2
 Fore
 SplineSet
-1008 570 m 1
- 1008 486 l 2
- 672 486 l 1
- 672 -336 l 1
- 588 -336 l 1
- 588 486 l 1
- 420 486 l 1
- 420 -336 l 1
- 336 -336 l 1
- 336 528 l 2
- 336 551.18043 354.81957 570 378 570 c 0
- 1008 570 1008 570 1008 570 c 1
+1008 612 m 1
+ 546 612 l 1
+ 546 444 l 1
+ 1008 444 l 1
+ 1008 360 l 1
+ 546 360 l 1
+ 546 -336 l 1
+ 462 -336 l 1
+ 462 654 l 2
+ 462 677.18043 480.81957 696 504 696 c 2
+ 1008 696 l 1
+ 1008 612 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -4025,18 +4025,18 @@ VStem: 462 84<-336 360 444 612>
 LayerCount: 2
 Fore
 SplineSet
-1008 612 m 1
- 546 612 l 1
- 546 444 l 1
- 1008 444 l 1
- 1008 360 l 1
- 546 360 l 1
- 546 -336 l 1
- 462 -336 l 1
- 462 654 l 2
- 462 677.18043 480.81957 696 504 696 c 2
- 1008 696 l 1
- 1008 612 l 1
+1008 570 m 1
+ 1008 486 l 2
+ 672 486 l 1
+ 672 -336 l 1
+ 588 -336 l 1
+ 588 486 l 1
+ 420 486 l 1
+ 420 -336 l 1
+ 336 -336 l 1
+ 336 528 l 2
+ 336 551.18043 354.81957 570 378 570 c 0
+ 1008 570 1008 570 1008 570 c 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -4079,18 +4079,18 @@ VStem: 336 84<-336 486> 588 84<-336 486>
 LayerCount: 2
 Fore
 SplineSet
-0 486 m 1
- 0 570 l 1
- 630 570 l 2
- 653.18043 570 672 551.18043 672 528 c 2
- 672 -336 l 1
- 588 -336 l 1
- 588 486 l 1
- 420 486 l 1
- 420 -336 l 1
- 336 -336 l 1
- 336 486 l 1
- 0 486 l 1
+462 -336 m 1
+ 462 360 l 1
+ 0 360 l 1
+ 0 444 l 1
+ 462 444 l 1
+ 462 612 l 1
+ 0 612 l 1
+ 0 696 l 1
+ 504 696 l 2
+ 527.18043 696 546 677.18043 546 654 c 0
+ 546 -336 546 -336 546 -336 c 1
+ 462 -336 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -4104,18 +4104,18 @@ VStem: 462 84<-336 360 444 612>
 LayerCount: 2
 Fore
 SplineSet
-462 -336 m 1
- 462 360 l 1
- 0 360 l 1
- 0 444 l 1
- 462 444 l 1
- 462 612 l 1
- 0 612 l 1
- 0 696 l 1
- 504 696 l 2
- 527.18043 696 546 677.18043 546 654 c 0
- 546 -336 546 -336 546 -336 c 1
- 462 -336 l 1
+0 486 m 1
+ 0 570 l 1
+ 630 570 l 2
+ 653.18043 570 672 551.18043 672 528 c 2
+ 672 -336 l 1
+ 588 -336 l 1
+ 588 486 l 1
+ 420 486 l 1
+ 420 -336 l 1
+ 336 -336 l 1
+ 336 486 l 1
+ 0 486 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -4158,18 +4158,18 @@ VStem: 336 84<570 1344> 588 84<570 1344>
 LayerCount: 2
 Fore
 SplineSet
-1008 570 m 1
- 1008 486 l 2
- 378 486 l 2
- 354.81957 486 336 504.81957 336 528 c 2
- 336 1344 l 1
- 420 1344 l 1
- 420 570 l 1
- 588 570 l 1
- 588 1344 l 1
- 672 1344 l 1
- 672 570 l 1
- 1008 570 l 1
+546 1344 m 1
+ 546 696 l 1
+ 1008 696 l 1
+ 1008 612 l 1
+ 546 612 l 1
+ 546 444 l 1
+ 1008 444 l 1
+ 1008 360 l 1
+ 504 360 l 2
+ 480.81957 360 462 378.81957 462 402 c 0
+ 462 1344 462 1344 462 1344 c 1
+ 546 1344 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -4183,18 +4183,18 @@ VStem: 462 84<444 612 696 1344>
 LayerCount: 2
 Fore
 SplineSet
-546 1344 m 1
- 546 696 l 1
- 1008 696 l 1
- 1008 612 l 1
- 546 612 l 1
- 546 444 l 1
- 1008 444 l 1
- 1008 360 l 1
- 504 360 l 2
- 480.81957 360 462 378.81957 462 402 c 0
- 462 1344 462 1344 462 1344 c 1
- 546 1344 l 1
+1008 570 m 1
+ 1008 486 l 2
+ 378 486 l 2
+ 354.81957 486 336 504.81957 336 528 c 2
+ 336 1344 l 1
+ 420 1344 l 1
+ 420 570 l 1
+ 588 570 l 1
+ 588 1344 l 1
+ 672 1344 l 1
+ 672 570 l 1
+ 1008 570 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -4237,18 +4237,18 @@ VStem: 336 84<570 1344> 588 84<570 1344>
 LayerCount: 2
 Fore
 SplineSet
-0 486 m 1
- 0 570 l 1
- 336 570 l 1
- 336 1344 l 1
- 420 1344 l 1
- 420 570 l 1
- 588 570 l 1
- 588 1344 l 1
- 672 1344 l 1
- 672 528 l 2
- 672 504.81957 653.18043 486 630 486 c 0
- 0 486 0 486 0 486 c 1
+0 444 m 1
+ 462 444 l 1
+ 462 612 l 1
+ 0 612 l 1
+ 0 696 l 1
+ 462 696 l 1
+ 462 1344 l 1
+ 546 1344 l 1
+ 546 402 l 2
+ 546 378.81957 527.18043 360 504 360 c 2
+ 0 360 l 1
+ 0 444 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -4262,18 +4262,18 @@ VStem: 462 84<444 612 696 1344>
 LayerCount: 2
 Fore
 SplineSet
-0 444 m 1
- 462 444 l 1
- 462 612 l 1
- 0 612 l 1
- 0 696 l 1
- 462 696 l 1
- 462 1344 l 1
- 546 1344 l 1
- 546 402 l 2
- 546 378.81957 527.18043 360 504 360 c 2
- 0 360 l 1
- 0 444 l 1
+0 486 m 1
+ 0 570 l 1
+ 336 570 l 1
+ 336 1344 l 1
+ 420 1344 l 1
+ 420 570 l 1
+ 588 570 l 1
+ 588 1344 l 1
+ 672 1344 l 1
+ 672 528 l 2
+ 672 504.81957 653.18043 486 630 486 c 0
+ 0 486 0 486 0 486 c 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar


### PR DESCRIPTION
This fixes the mixed-up single-double box drawing corners:

Before:

<img width="1092" height="201" alt="Bildschirmfoto vom 2026-02-16 12-12-3822" src="https://github.com/user-attachments/assets/9bd171e2-cef4-4b86-82b8-facae7efcfcc" />

After:

<img width="643" height="95" alt="Bildschirmfoto vom 2026-02-20 18-46-45" src="https://github.com/user-attachments/assets/c6674eab-2646-4d97-83b1-f49f9d89c3c4" />
