### PR TITLE
Fix widths of single-angle mixed-width box corners

### DIFF
--- a/src/basefont/OldTimeyMono.sfd
+++ b/src/basefont/OldTimeyMono.sfd
@@ -2456,13 +2456,13 @@ VStem: 462 84<-336 444>
 LayerCount: 2
 Fore
 SplineSet
-462 612 m 1
- 1008 612 l 1
- 1008 444 l 1
- 546 444 l 1
+462 654 m 1
+ 1008 654 l 1
+ 1008 402 l 1
+ 546 402 l 1
  546 -336 l 1
  462 -336 l 1
- 462 612 l 1
+ 462 654 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -2476,13 +2476,13 @@ VStem: 420 168<-336 486>
 LayerCount: 2
 Fore
 SplineSet
-420 570 m 1
+378 570 m 1
  1008 570 l 1
  1008 486 l 1
- 588 486 l 1
- 588 -336 l 1
- 420 -336 l 1
- 420 570 l 1
+ 630 486 l 1
+ 630 -336 l 1
+ 378 -336 l 1
+ 378 570 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -2496,13 +2496,13 @@ VStem: 420 168<-336 444>
 LayerCount: 2
 Fore
 SplineSet
-420 612 m 1
- 1008 612 l 1
- 1008 444 l 1
- 588 444 l 1
- 588 -336 l 1
- 420 -336 l 1
- 420 612 l 1
+378 654 m 1
+ 1008 654 l 1
+ 1008 402 l 1
+ 630 402 l 1
+ 630 -336 l 1
+ 378 -336 l 1
+ 378 654 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -2533,14 +2533,13 @@ Flags: W
 VStem: 0 546
 LayerCount: 2
 Fore
-SplineSet
-546 612 m 1
- 0 612 l 1
- 0 444 l 1
- 462 444 l 1
- 462 -336 l 1
+0 654 m 1
+ 546 654 l 1
  546 -336 l 1
- 546 612 l 1
+ 462 -336 l 1
+ 462 402 l 1
+ 0 402 l 1
+ 0 654 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -2552,13 +2551,13 @@ Flags: W
 LayerCount: 2
 Fore
 SplineSet
-588 570 m 1
+630 570 m 1
  0 570 l 1
  0 486 l 1
- 420 486 l 1
- 420 -336 l 1
- 588 -336 l 1
- 588 570 l 1
+ 378 486 l 1
+ 378 -336 l 1
+ 630 -336 l 1
+ 630 570 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -2570,13 +2569,13 @@ Flags: W
 LayerCount: 2
 Fore
 SplineSet
-588 612 m 1
- 0 612 l 1
- 0 444 l 1
- 420 444 l 1
- 420 -336 l 1
- 588 -336 l 1
- 588 612 l 1
+0 654 m 1xa0
+ 630 654 l 1xa0
+ 630 -336 l 1
+ 378 -336 l 1
+ 378 402 l 1
+ 0 402 l 1
+ 0 654 l 1xa0
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -2608,13 +2607,14 @@ VStem: 462 546
 LayerCount: 2
 Fore
 SplineSet
-462 444 m 1
- 1008 444 l 1
- 1008 612 l 1
- 546 612 l 1
+462 1344 m 1
  546 1344 l 1
+ 546 654 l 1
+ 1008 654 l 1
+ 1008 402 l 1
+ 546 402 l 1
+ 462 402 l 1
  462 1344 l 1
- 462 444 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -2626,13 +2626,13 @@ Flags: W
 LayerCount: 2
 Fore
 SplineSet
-420 486 m 1
- 1008 486 l 1
+378 1344 m 1xc0
+ 630 1344 l 1
+ 630 570 l 1xc0
  1008 570 l 1
- 588 570 l 1
- 588 1344 l 1
- 420 1344 l 1
- 420 486 l 1
+ 1008 486 l 1
+ 378 486 l 1
+ 378 1344 l 1xc0
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -2644,13 +2644,13 @@ Flags: W
 LayerCount: 2
 Fore
 SplineSet
-420 444 m 1
- 1008 444 l 1
- 1008 612 l 1
- 588 612 l 1
- 588 1344 l 1
- 420 1344 l 1
- 420 444 l 1
+378 402 m 1
+ 1008 402 l 1
+ 1008 654 l 1
+ 630 654 l 1
+ 630 1344 l 1
+ 378 1344 l 1
+ 378 402 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -2684,13 +2684,13 @@ VStem: 462 84<612 1344>
 LayerCount: 2
 Fore
 SplineSet
-546 444 m 1
- 0 444 l 1
- 0 612 l 1
- 462 612 l 1
+546 1344 m 1
  462 1344 l 1
+ 462 654 l 1
+ 0 654 l 1
+ 0 402 l 1
+ 546 402 l 1
  546 1344 l 1
- 546 444 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -2704,13 +2704,13 @@ VStem: 420 168<570 1344>
 LayerCount: 2
 Fore
 SplineSet
-588 486 m 1
- 0 486 l 1
+630 1344 m 1
+ 378 1344 l 1
+ 378 570 l 1
  0 570 l 1
- 420 570 l 1
- 420 1344 l 1
- 588 1344 l 1
- 588 486 l 1
+ 0 486 l 1
+ 630 486 l 1
+ 630 1344 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar
@@ -2724,13 +2724,13 @@ VStem: 420 168<612 1344>
 LayerCount: 2
 Fore
 SplineSet
-588 444 m 1
- 0 444 l 1
- 0 612 l 1
- 420 612 l 1
- 420 1344 l 1
- 588 1344 l 1
- 588 444 l 1
+630 1344 m 1
+ 378 1344 l 1
+ 378 654 l 1
+ 0 654 l 1
+ 0 402 l 1
+ 630 402 l 1
+ 630 1344 l 1
 EndSplineSet
 Comment: "{+AAoA    +ACIA__space__+ACIA: +ACIA-com.webonastick.fontcomment+ACIA,+AAoA    +ACIA-generator+ACIA: +ACIA-fontboxdraw+ACIACgAA}"
 EndChar


### PR DESCRIPTION
This fixes the bold parts of the mixed-width single-angle box corner characters to match the widths of the other (partially) bold box elements.

Before:

<img width="796" height="682" alt="Bildschirmfoto vom 2026-02-20 20-08-20" src="https://github.com/user-attachments/assets/d57bb1a9-6f7b-4103-a6a5-eda348bd4e61" />

After:

<img width="796" height="682" alt="Bildschirmfoto vom 2026-02-20 20-08-34" src="https://github.com/user-attachments/assets/c7809d06-1a8e-4477-8a25-76ffc7438671" />
